### PR TITLE
Fix: block words: skip empty string

### DIFF
--- a/src/Flows.js
+++ b/src/Flows.js
@@ -448,7 +448,7 @@ class FlowItemRow extends PureComponent {
       reply_status: 'done',
       reply_error: null,
       info: Object.assign({}, props.info, {variant: {}}),
-      hidden: window.config.block_words.some(word => props.info.text.includes(word)),
+      hidden: window.config.block_words.some(word => props.info.text.includes(word) && word != ''),
       attention: props.attention_override === null ? false : props.attention_override,
       cached: true, // default no display anything
     };


### PR DESCRIPTION
- fix: 跳过屏蔽词列表里的空字符串