### PR TITLE
perf(reverse): speed up reverse 10x

### DIFF
--- a/src/Flows.js
+++ b/src/Flows.js
@@ -460,9 +460,10 @@ class FlowSidebar extends PureComponent {
       : this.state.replies.slice();
     if (this.state.rev) replies_to_show.reverse();
 
+    // may not need key, for performance
     // key for lazyload elem
-    let view_mode_key =
-      (this.state.rev ? 'y-' : 'n-') + (this.state.filter_name || 'null');
+    // let view_mode_key =
+    //   (this.state.rev ? 'y-' : 'n-') + (this.state.filter_name || 'null');
 
     let replies_cnt = { [DZ_NAME]: 1 };
     replies_to_show.forEach((r) => {
@@ -580,9 +581,9 @@ class FlowSidebar extends PureComponent {
               条回复被删除
             </div>
           )}
-        {replies_to_show.map((reply) => (
+        {replies_to_show.map((reply, i) => (
           <LazyLoad
-            key={reply.cid + view_mode_key}
+            key={i}
             offset={1500}
             height="5em"
             overflow={true}


### PR DESCRIPTION
Setting key to cid + mode_key will lead to unmounnting LazyLoad every
    time, big delay on thousands of replies.
Setting key to index can prevent this (don't ask me why)

---

以上 commit message

以“回复分类”为例，原来耗时 10 秒，改动后耗时约 1 秒。 

<details><summary>profile 如下（未全部展示）</summary>

原来：逆序，恢复，只看洞主，恢复，刷新
![image](https://user-images.githubusercontent.com/36528777/85273014-92006f80-b4af-11ea-8b5c-958f31c3fae2.png)
改动后：逆序，恢复，只看洞主，恢复
![image](https://user-images.githubusercontent.com/36528777/85273006-8e6ce880-b4af-11ea-9a76-8987a6dc4889.png)
</details>

但是仍然有问题：
- 文档的确建议为每个元素设置一个唯一的 key，但是改为 `reply.cid` 效果也并不明显？（触及知识盲区）
- 此改动与 LazyLoad 的合作是否愉快不确定
- xmcp 对 react-lazyload 的改动 `hiddenIfInvisible` （对不显示的元素加 `visibility: hidden`）似乎并没有多少 performance gain？ `hidden` 的元素依然会被计算，只是不显示而已。

故这一改动有待观察