### PR TITLE
对回复使用 virtual-scroll

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "src/react-lazyload"]
-	path = src/react-lazyload
-	url = https://github.com/xmcp/react-lazyload
-
 [submodule "src/infrastructure"]
 	path = src/infrastructure
 	url = https://github.com/pkuhelper-web/infrastructure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,6 +1382,16 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
+    },
+    "@scarf/scarf": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.6.tgz",
+      "integrity": "sha512-y4+DuXrAd1W5UIY3zTcsosi/1GyYT8k5jGnZ/wG7UUHVrU+MHlH4Mp87KK2/lvMW4+H7HVcdB+aJhqywgXksjA=="
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -11366,6 +11376,16 @@
       "resolved": "https://registry.npmjs.org/react-timeago/-/react-timeago-4.4.0.tgz",
       "integrity": "sha512-Zj8RchTqZEH27LAANemzMR2RpotbP2aMd+UIajfYMZ9KW4dMcViUVKzC7YmqfiqlFfz8B0bjDw2xUBjmcxDngA=="
     },
+    "react-virtual": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.2.0.tgz",
+      "integrity": "sha512-ZiXj6DwHuUT4KRWl4GxkvF+WzQTXRmLn8+fgMbrsHB23NQeH+4rWB9NykzhzqwbZF/c5vzzT2MPcl3N+OgrDaA==",
+      "requires": {
+        "@reach/observe-rect": "^1.1.0",
+        "@scarf/scarf": "^1.0.0",
+        "ts-toolbelt": "^6.4.2"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -13597,6 +13617,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
       "integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ=="
+    },
+    "ts-toolbelt": {
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.9.9.tgz",
+      "integrity": "sha512-5a8k6qfbrL54N4Dw+i7M6kldrbjgDWb5Vit8DnT+gwThhvqMg8KtxLE5Vmnft+geIgaSOfNJyAcnmmlflS+Vdg=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11105,6 +11105,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
+    "react-lazyload": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.0.0.tgz",
+      "integrity": "sha512-wYR9iroanIUELPQ7YtgeHjl7KburmA1WxB2GurjAOs31B6IehxxvHEp/74pIaWJLv+o/ug952WoWqjFpDzl5Ig=="
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.0",
     "react-scripts": "^3.4.1",
-    "react-timeago": "^4.4.0"
+    "react-timeago": "^4.4.0",
+    "react-virtual": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pressure": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.0",
+    "react-lazyload": "^3.0.0",
     "react-scripts": "^3.4.1",
     "react-timeago": "^4.4.0",
     "react-virtual": "^2.2.0"

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -12,7 +12,7 @@ export default React.forwardRef(({ rows, head, foot, children }, ref) => {
    * Conclusion: change recalc to recalculate
    */
   const rowVirtualizer = useVirtual({
-    size: rows.length + 2,
+    size: rows.length + 1,
     parentRef,
     estimateSize: React.useCallback(() => 50, [recalc]),
   });
@@ -34,6 +34,7 @@ export default React.forwardRef(({ rows, head, foot, children }, ref) => {
     return () => window.removeEventListener('resize', recalculate);
   });
 
+  const defaultContent = <div style={{ height: '0.5em' }} />;
   return (
     <>
       <div
@@ -54,12 +55,6 @@ export default React.forwardRef(({ rows, head, foot, children }, ref) => {
         >
           {rowVirtualizer.virtualItems.map((virtualRow) => {
             const index = virtualRow.index;
-            let content = <div style={{ height: '0.5em' }} />;
-            if (index === rows.length + 1) {
-              if (foot) content = foot;
-            } else if (index === 0) {
-              if (head) content = head;
-            } else content = children(rows[index - 1]);
             return (
               <div
                 key={index}
@@ -72,11 +67,12 @@ export default React.forwardRef(({ rows, head, foot, children }, ref) => {
                   marginTop: `${virtualRow.start}px`,
                 }}
               >
-                {content}
+                {index ? children(rows[index - 1]) : head || defaultContent}
               </div>
             );
           })}
         </div>
+        {foot ? foot : defaultContent}
       </div>
     </>
   );

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -42,7 +42,6 @@ export default React.forwardRef(({ rows, children }, ref) => {
                 top: 0,
                 left: 0,
                 width: '100%',
-                height: `${rows[virtualRow.index]}px`,
                 marginTop: `${virtualRow.start}px`,
               }}
             >

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -1,76 +1,79 @@
 import React from 'react';
 import { useVirtual } from 'react-virtual';
 
-export default React.forwardRef(({ rows, head, foot, children }, ref) => {
-  const parentRef = React.useRef();
-  const [recalc, setRecalc] = React.useState(0);
-  /**
-   * Making use of React useCallback and react-virtual feature
-   * react-virtual will recalculate height on estimateSize change
-   * React will change useCallback on recalc change,
-   *    even function does not
-   * Conclusion: change recalc to recalculate
-   */
-  const rowVirtualizer = useVirtual({
-    size: rows.length + 1,
-    parentRef,
-    estimateSize: React.useCallback(() => 50, [recalc]),
-  });
+export default React.forwardRef(
+  ({ rows, head, sticky, foot, children }, ref) => {
+    const parentRef = React.useRef();
+    const [recalc, setRecalc] = React.useState(0);
+    /**
+     * Making use of React useCallback and react-virtual feature
+     * react-virtual will recalculate height on estimateSize change
+     * React will change useCallback on recalc change,
+     *    even function does not
+     * Conclusion: change recalc to recalculate
+     */
+    const rowVirtualizer = useVirtual({
+      size: rows.length + 1,
+      parentRef,
+      estimateSize: React.useCallback(() => 50, [recalc]),
+    });
 
-  const recalculate = () => setRecalc(recalc + 1);
+    const recalculate = () => setRecalc(recalc + 1);
 
-  React.useImperativeHandle(ref, () => ({
-    toggleRev() {
-      recalculate();
-      parentRef.current.scrollTo(0, 0);
-    },
-  }));
+    React.useImperativeHandle(ref, () => ({
+      toggleRev() {
+        recalculate();
+        parentRef.current.scrollTo(0, 0);
+      },
+    }));
 
-  React.useEffect(() => {
-    window.addEventListener('resize', recalculate);
-    return () => window.removeEventListener('resize', recalculate);
-  });
+    React.useEffect(() => {
+      window.addEventListener('resize', recalculate);
+      return () => window.removeEventListener('resize', recalculate);
+    });
 
-  const defaultContent = <div style={{ height: '0.5em' }} />;
-  return (
-    <>
-      <div
-        ref={parentRef}
-        className="no-scrollbar"
-        style={{
-          maxHeight: `100%`,
-          width: `100%`,
-          overflowY: 'auto',
-        }}
-      >
+    const defaultContent = <div style={{ height: '0em' }} />;
+    return (
+      <>
         <div
+          ref={parentRef}
+          className="no-scrollbar"
           style={{
-            height: `${rowVirtualizer.totalSize}px`,
-            width: '100%',
-            position: 'relative',
+            maxHeight: `100%`,
+            width: `100%`,
+            overflowY: 'auto',
           }}
         >
-          {rowVirtualizer.virtualItems.map((virtualRow) => {
-            const index = virtualRow.index;
-            return (
-              <div
-                key={index}
-                ref={virtualRow.measureRef}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  marginTop: `${virtualRow.start}px`,
-                }}
-              >
-                {index ? children(rows[index - 1]) : head || defaultContent}
-              </div>
-            );
-          })}
+          {sticky ? sticky : defaultContent}
+          <div
+            style={{
+              height: `${rowVirtualizer.totalSize}px`,
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            {rowVirtualizer.virtualItems.map((virtualRow) => {
+              const index = virtualRow.index;
+              return (
+                <div
+                  key={index}
+                  ref={virtualRow.measureRef}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    marginTop: `${index ? virtualRow.start : 0}px`,
+                  }}
+                >
+                  {index ? children(rows[index - 1]) : head || defaultContent}
+                </div>
+              );
+            })}
+          </div>
+          {foot ? foot : defaultContent}
         </div>
-        {foot ? foot : defaultContent}
-      </div>
-    </>
-  );
-});
+      </>
+    );
+  },
+);

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -17,10 +17,7 @@ export default React.forwardRef(({ rows, head, foot, children }, ref) => {
     estimateSize: React.useCallback(() => 50, [recalc]),
   });
 
-  const recalculate = () => {
-    console.log('resize');
-    setRecalc(recalc + 1);
-  };
+  const recalculate = () => setRecalc(recalc + 1);
 
   React.useImperativeHandle(ref, () => ({
     toggleRev() {

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useVirtual } from 'react-virtual';
+
+export default React.forwardRef(({ rows, children }, ref) => {
+  const parentRef = React.useRef();
+
+  const rowVirtualizer = useVirtual({
+    size: rows.length,
+    parentRef,
+  });
+
+  React.useImperativeHandle(ref, () => ({
+    toTop() {
+      parentRef.current.scrollTo(0, 0);
+    },
+  }));
+
+  return (
+    <>
+      <div
+        ref={parentRef}
+        className="List"
+        style={{
+          maxHeight: `80vh`,
+          width: `100%`,
+          overflow: 'auto',
+        }}
+      >
+        <div
+          style={{
+            height: `${rowVirtualizer.totalSize}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {rowVirtualizer.virtualItems.map((virtualRow) => (
+            <div
+              key={virtualRow.index}
+              ref={virtualRow.measureRef}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${rows[virtualRow.index]}px`,
+                marginTop: `${virtualRow.start}px`,
+              }}
+            >
+              {children(rows[virtualRow.index])}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+});

--- a/src/DynVirtualRow.js
+++ b/src/DynVirtualRow.js
@@ -3,31 +3,36 @@ import { useVirtual } from 'react-virtual';
 
 export default React.forwardRef(({ rows, head, foot, children }, ref) => {
   const parentRef = React.useRef();
-  const [rev, setRev] = React.useState(false);
+  const [recalc, setRecalc] = React.useState(0);
+  /**
+   * Making use of React useCallback and react-virtual feature
+   * react-virtual will recalculate height on estimateSize change
+   * React will change useCallback on recalc change,
+   *    even function does not
+   * Conclusion: change recalc to recalculate
+   */
   const rowVirtualizer = useVirtual({
     size: rows.length + 2,
     parentRef,
-    estimateSize: React.useCallback(
-      (index) =>
-        index === 0
-          ? rev
-            ? 10
-            : 100
-          : index === rows.length + 1
-          ? rev
-            ? 100
-            : 50
-          : 30,
-      [rev],
-    ),
+    estimateSize: React.useCallback(() => 50, [recalc]),
   });
+
+  const recalculate = () => {
+    console.log('resize');
+    setRecalc(recalc + 1);
+  };
 
   React.useImperativeHandle(ref, () => ({
     toggleRev() {
-      setRev(!rev);
+      recalculate();
       parentRef.current.scrollTo(0, 0);
     },
   }));
+
+  React.useEffect(() => {
+    window.addEventListener('resize', recalculate);
+    return () => window.removeEventListener('resize', recalculate);
+  });
 
   return (
     <>

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -50,6 +50,10 @@
     overflow-x: auto;
 }
 
+.sidebar-flow-item .flow-reply {
+    margin: 8px 0;
+}
+
 .sidebar-flow-item .flow-item pre, .sidebar-flow-item .flow-reply pre {
     cursor: text;
 }

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -262,6 +262,12 @@
     background-color: #00a;
 }
 
+.filter-name-bar {
+    animation: slide-in-from-top .15s ease-out;
+    position: sticky;
+    top: 1em;
+}
+
 @keyframes slide-in-from-top {
     0%   {opacity: 0; transform: translateY(-50%);}
     100% {opacity: 1;}
@@ -271,4 +277,8 @@
     float: right;
     padding: 0 .5em;
     opacity: .4;
+}
+
+.virtual-scroll-head .box {
+    margin-bottom: 0.5em;
 }

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -58,14 +58,6 @@
     cursor: text;
 }
 
-.flow-reply-row::-webkit-scrollbar {
-    display: none;
-}
-.flow-reply-row {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-}
-
 .flow-reply-row:empty {
     margin: 0 !important;
     display: none;
@@ -268,12 +260,6 @@
 
 .root-dark-mode .box-header-tag {
     background-color: #00a;
-}
-
-.filter-name-bar {
-    animation: slide-in-from-top .15s ease-out;
-    position: sticky;
-    top: 1em;
 }
 
 @keyframes slide-in-from-top {

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -498,7 +498,7 @@ class FlowSidebar extends PureComponent {
         </ClickHandler>
       );
     const head_tool_bar = (
-      <div className="box box-tip">
+      <div className="box box-tip box-head-tool-bar">
         {!!this.props.token && (
           <span>
             <a onClick={this.report.bind(this)}>
@@ -566,9 +566,8 @@ class FlowSidebar extends PureComponent {
       </div>
     );
     const head = (
-      <div>
+      <div className="virtual-scroll-head">
         {head_tool_bar}
-        {filter_name_bar}
         {!this.state.rev && main_thread_elem}
         {!!this.state.error_msg && (
           <div className="box box-tip flow-item">
@@ -586,6 +585,7 @@ class FlowSidebar extends PureComponent {
           )}
       </div>
     );
+    const sticky = filter_name_bar;
     const foot = (
       <>
         {this.state.rev && main_thread_elem}
@@ -608,6 +608,7 @@ class FlowSidebar extends PureComponent {
           ref={this.scroll_ref}
           rows={replies_to_show}
           head={head}
+          sticky={sticky}
           foot={foot}
         >
           {(reply) => (

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import copy from 'copy-to-clipboard';
+import LazyLoad from 'react-lazyload';
 import DynVirtualRow from './DynVirtualRow';
 import { ColorPicker } from './color_picker';
 import {
@@ -19,7 +20,6 @@ import {
   ColoredSpan,
 } from './Common';
 import './Flows.css';
-import LazyLoad from './react-lazyload/src';
 import { AudioWidget } from './AudioWidget';
 import { TokenCtx, ReplyForm } from './UserAction';
 
@@ -968,12 +968,7 @@ function FlowChunk(props) {
         <div className="flow-chunk">
           {!!props.title && <TitleLine text={props.title} />}
           {props.list.map((info, ind) => (
-            <LazyLoad
-              key={info.pid}
-              offset={1500}
-              height="15em"
-              hiddenIfInvisible={true}
-            >
+            <LazyLoad key={info.pid} offset={1500} height="15em" once>
               <div>
                 {!!(
                   props.deletion_detect &&

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import copy from 'copy-to-clipboard';
+import DynVirtualRow from './DynVirtualRow';
 import { ColorPicker } from './color_picker';
 import {
   split_text,
@@ -301,6 +302,7 @@ class FlowSidebar extends PureComponent {
     this.color_picker = props.color_picker;
     this.syncState = props.sync_state || (() => {});
     this.reply_ref = React.createRef();
+    this.scroll_ref = React.createRef();
   }
 
   set_variant(cid, variant) {
@@ -430,6 +432,7 @@ class FlowSidebar extends PureComponent {
     this.setState((prevState) => ({
       rev: !prevState.rev,
     }));
+    this.scroll_ref.current.toTop();
   }
 
   show_reply_bar(name, event) {
@@ -580,14 +583,8 @@ class FlowSidebar extends PureComponent {
               条回复被删除
             </div>
           )}
-        {replies_to_show.map((reply) => (
-          <LazyLoad
-            key={reply.cid + view_mode_key}
-            offset={1500}
-            height="5em"
-            overflow={true}
-            once={true}
-          >
+        <DynVirtualRow ref={this.scroll_ref} rows={replies_to_show}>
+          {(reply) => (
             <ClickHandler
               callback={(e) => {
                 this.show_reply_bar(reply.name, e);
@@ -607,8 +604,8 @@ class FlowSidebar extends PureComponent {
                 }
               />
             </ClickHandler>
-          </LazyLoad>
-        ))}
+          )}
+        </DynVirtualRow>
         {this.state.rev && main_thread_elem}
         {this.props.token ? (
           <ReplyForm

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -587,7 +587,7 @@ class FlowSidebar extends PureComponent {
       </div>
     );
     const foot = (
-      <div>
+      <>
         {this.state.rev && main_thread_elem}
         {this.props.token ? (
           <ReplyForm
@@ -599,7 +599,7 @@ class FlowSidebar extends PureComponent {
         ) : (
           <div className="box box-tip flow-item">登录后可以回复树洞</div>
         )}
-      </div>
+      </>
     );
 
     return (

--- a/src/Sidebar.css
+++ b/src/Sidebar.css
@@ -145,6 +145,7 @@
 
 .sidebar-flow-item {
     display: block;
+    height: 100%;
 }
 .sidebar-flow-item .box {
     width: 100%;
@@ -152,7 +153,6 @@
 
 .sidebar-content-show {
     height: 100%;
-    overflow-y: scroll;
 }
 .sidebar-content-hide{
     display: none;

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,11 @@ button:disabled, .button:disabled {
 .root-dark-mode input:not([type=file])::placeholder {
     color: var(--foreground-dark);
 }
+
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+}
+.no-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}


### PR DESCRIPTION
### 解决的问题

回复中的逆序和筛选操作由于大量的 mount unmount, 操作 DOM, 导致时间效率低下. 对于上千回复耗时近 10 秒

### virtual-scroll 简介

只有框内可见及附近范围的元素才会 mount, 不可见的会 unmount. 保持 DOM 元素处于较少的水平. 那么逆序和筛选操作速度有很大提升.

#### virtual-scroll 的问题

(老牌的库 react-virtualized 体积过大, 不太友好)

难点在于每个元素位置的计算. 对于频繁发生变化的元素如 `FlowItemRow`, 计算准确性尚不论, 性能也会降低 (如 react-virtuoso), 甚至出现 mount unmount... 的死循环.

同时, virtual-scroll 不能或很难实现状态保留, 对于现在的时间线的结构处理并不友好.

综合考虑仅对回复使用 `react-virtual` (2kB min + gzip)

### 顺道的性能问题

xmcp fork 了 react-lazyload 的代码并添加了 `hideIfInvisible` 的功能. 但是 hide 的元素依然参加 layout 计算, 同时也一直有 event listener, 而且测试出来也没有很大差别. 二来 react-lazyload 近期有适应 React 的更新. 我觉得还是使用 react-lazyload 原本提供的功能

### Behavior Change

"当前只看洞主" 不再 sticky