### PR TITLE
feat: alias

### DIFF
--- a/src/Config.css
+++ b/src/Config.css
@@ -4,9 +4,21 @@
     position: sticky;
 }
 
-.block-words {
+.config-description {
+    font-size: 0.75em;
+}
+
+.config-select {
+    height: 2em;
+}
+
+.config-textarea {
+    margin-top: 0.5em;
     width: 100%;
+    max-width: 100%;
+    min-width: 100%;
     height: 7em;
+    min-height: 2em;
 }
 
 .bg-preview {

--- a/src/Config.js
+++ b/src/Config.js
@@ -107,7 +107,11 @@ class ConfigBackground extends PureComponent {
       <div>
         <p>
           <b>背景图片：</b>
-          <select value={img_select} onChange={this.on_select.bind(this)}>
+          <select
+            className="config-select"
+            value={img_select}
+            onChange={this.on_select.bind(this)}
+          >
             {Object.keys(BUILTIN_IMGS).map((key) => (
               <option key={key} value={key}>
                 {BUILTIN_IMGS[key]}
@@ -117,6 +121,7 @@ class ConfigBackground extends PureComponent {
             <option value="##color">纯色背景……</option>
           </select>
           &nbsp;
+          <small>#background_img</small>&nbsp;
           {img_select === '##other' && (
             <input
               type="url"
@@ -172,6 +177,7 @@ class ConfigColorScheme extends PureComponent {
         <p>
           <b>夜间模式：</b>
           <select
+            className="config-select"
             value={this.state.color_scheme}
             onChange={this.on_select.bind(this)}
           >
@@ -179,15 +185,62 @@ class ConfigColorScheme extends PureComponent {
             <option value="light">始终浅色模式</option>
             <option value="dark">始终深色模式</option>
           </select>
-          <small>#color_scheme</small>
+          &nbsp;<small>#color_scheme</small>
         </p>
-        <p>选择浅色或深色模式，深色模式下将会调暗图片亮度</p>
+        <p className="config-description">
+          选择浅色或深色模式，深色模式下将会调暗图片亮度
+        </p>
       </div>
     );
   }
 }
 
-class ConfigBlockWords extends PureComponent {
+class ConfigTextArea extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      [props.id]: window.config[props.id],
+    };
+  }
+
+  save_changes() {
+    this.props.callback({
+      [this.props.id]: this.props.sift(this.state[this.props.id]),
+    });
+  }
+
+  on_change(e) {
+    let value = this.props.parse(e.target.value);
+    this.setState(
+      {
+        [this.props.id]: value,
+      },
+      this.save_changes.bind(this),
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <label>
+          <p>
+            <b>{this.props.name}</b>&nbsp;<small>#{this.props.id}</small>
+          </p>
+          <p className="config-description">{this.props.description}</p>
+          <textarea
+            name={'config-' + this.props.id}
+            id={`config-textarea-${this.props.id}`}
+            className="config-textarea"
+            value={this.props.display(this.state[this.props.id])}
+            onChange={this.on_change.bind(this)}
+          />
+        </label>
+      </div>
+    );
+  }
+}
+
+/* class ConfigBlockWords extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -229,7 +282,7 @@ class ConfigBlockWords extends PureComponent {
       </div>
     );
   }
-}
+} */
 
 class ConfigSwitch extends PureComponent {
   constructor(props) {
@@ -264,11 +317,11 @@ class ConfigSwitch extends PureComponent {
               checked={this.state.switch}
               onChange={this.on_change.bind(this)}
             />
-            <b>{this.props.name}</b>
-            <small>#{this.props.id}</small>
+            &nbsp;<b>{this.props.name}</b>
+            &nbsp;<small>#{this.props.id}</small>
           </label>
         </p>
-        <p>{this.props.description}</p>
+        <p className="config-description">{this.props.description}</p>
       </div>
     );
   }
@@ -319,11 +372,29 @@ export class ConfigUI extends PureComponent {
           </p>
         </div>
         <div className="box">
-          <ConfigBackground callback={this.save_changes_bound} />
+          <ConfigBackground
+            id="background"
+            callback={this.save_changes_bound}
+          />
           <hr />
-          <ConfigColorScheme callback={this.save_changes_bound} />
+          <ConfigColorScheme
+            id="color-scheme"
+            callback={this.save_changes_bound}
+          />
           <hr />
-          <ConfigBlockWords callback={this.save_changes_bound} />
+          {/* <ConfigBlockWords
+            id="block-words"
+            callback={this.save_changes_bound}
+          /> */}
+          <ConfigTextArea
+            id="block_words"
+            callback={this.save_changes_bound}
+            name="设置屏蔽词"
+            description={'包含屏蔽词的树洞会被折叠，每行写一个屏蔽词'}
+            display={(array) => array.join('\n')}
+            sift={(array) => array.filter((v) => v)}
+            parse={(string) => string.split('\n')}
+          />
           <hr />
           <ConfigSwitch
             callback={this.save_changes_bound}
@@ -342,7 +413,7 @@ export class ConfigUI extends PureComponent {
           <p>
             新功能建议或问题反馈请在&nbsp;
             <a
-              href="https://github.com/pkuhelper-web/webhole/issues"
+              href="https://github.com/AllanChain/PKUHoleCommunity/issues"
               target="_blank"
             >
               GitHub <span className="icon icon-github" />

--- a/src/Config.js
+++ b/src/Config.js
@@ -199,24 +199,36 @@ class ConfigTextArea extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      [props.id]: window.config[props.id],
+      [props.id]: this.props.display(window.config[props.id]),
     };
   }
 
-  save_changes() {
+  /* save_changes() {
     this.props.callback({
       [this.props.id]: this.props.sift(this.state[this.props.id]),
     });
-  }
+  } */
 
-  on_change(e) {
-    let value = this.props.parse(e.target.value);
+  on_blur(e) {
+    let value = e.target.value;
+    let parsed = this.props.parse(value);
     this.setState(
       {
         [this.props.id]: value,
       },
-      this.save_changes.bind(this),
+      () => {
+        this.props.callback({
+          [this.props.id]: parsed,
+        });
+      },
     );
+  }
+
+  on_change(e) {
+    let value = e.target.value;
+    this.setState((state) => {
+      return { [this.props.id]: value };
+    });
   }
 
   render() {
@@ -231,8 +243,9 @@ class ConfigTextArea extends PureComponent {
             name={'config-' + this.props.id}
             id={`config-textarea-${this.props.id}`}
             className="config-textarea"
-            value={this.props.display(this.state[this.props.id])}
+            value={this.state[this.props.id]}
             onChange={this.on_change.bind(this)}
+            onBlur={this.on_blur.bind(this)}
           />
         </label>
       </div>
@@ -392,8 +405,7 @@ export class ConfigUI extends PureComponent {
             name="设置屏蔽词"
             description={'包含屏蔽词的树洞会被折叠，每行写一个屏蔽词'}
             display={(array) => array.join('\n')}
-            sift={(array) => array.filter((v) => v)}
-            parse={(string) => string.split('\n')}
+            parse={(string) => string.split('\n').filter((v) => v)}
           />
           <hr />
           <ConfigSwitch

--- a/src/Config.js
+++ b/src/Config.js
@@ -254,50 +254,6 @@ class ConfigTextArea extends PureComponent {
   }
 }
 
-/* class ConfigBlockWords extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      block_words: window.config.block_words,
-    };
-  }
-
-  save_changes() {
-    this.props.callback({
-      block_words: this.state.block_words.filter((v) => v),
-    });
-  }
-
-  on_change(e) {
-    // Filter out those blank lines
-    let value = e.target.value.split('\n');
-    this.setState(
-      {
-        block_words: value,
-      },
-      this.save_changes.bind(this),
-    );
-  }
-
-  render() {
-    return (
-      <div>
-        <p>
-          {' '}
-          <b>设置屏蔽词 </b>
-        </p>
-        <p>
-          <textarea
-            className="block-words"
-            value={this.state.block_words.join('\n')}
-            onChange={this.on_change.bind(this)}
-          />
-        </p>
-      </div>
-    );
-  }
-} */
-
 class ConfigSwitch extends PureComponent {
   constructor(props) {
     super(props);
@@ -396,10 +352,6 @@ export class ConfigUI extends PureComponent {
             callback={this.save_changes_bound}
           />
           <hr />
-          {/* <ConfigBlockWords
-            id="block-words"
-            callback={this.save_changes_bound}
-          /> */}
           <ConfigTextArea
             id="block_words"
             callback={this.save_changes_bound}

--- a/src/Config.js
+++ b/src/Config.js
@@ -17,6 +17,7 @@ const DEFAULT_CONFIG = {
   easter_egg: true,
   color_scheme: 'default',
   block_words: [],
+  alias: {},
 };
 
 export function load_config() {
@@ -406,6 +407,37 @@ export class ConfigUI extends PureComponent {
             description={'包含屏蔽词的树洞会被折叠，每行写一个屏蔽词'}
             display={(array) => array.join('\n')}
             parse={(string) => string.split('\n').filter((v) => v)}
+          />
+          <hr />
+          <ConfigTextArea
+            id="alias"
+            callback={this.save_changes_bound}
+            name="设置别名"
+            description={`可用 #别名 代替 #PID（树洞号）进行查询，每行由树洞号、半角空格、别名顺序连接，如“472865 网页版发布”，别名中不可包含空格`}
+            display={(map) =>
+              Object.entries(map)
+                .map((pair) => pair[1] + ' ' + pair[0])
+                .reduce(
+                  (accumulator, currentValue) =>
+                    !!accumulator
+                      ? currentValue + '\n' + accumulator
+                      : currentValue,
+                  '',
+                )
+            }
+            parse={(string) => {
+              let map = {};
+              string
+                .split('\n')
+                .filter((value) => value)
+                .forEach((line) => {
+                  let pair = line.split(' ');
+                  if (pair.length === 2 && !isNaN(Number(pair[0]))) {
+                    map[pair[1]] = Number(pair[0]);
+                  }
+                });
+              return map;
+            }}
           />
           <hr />
           <ConfigSwitch

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -1079,7 +1079,9 @@ export class Flow extends PureComponent {
           })
           .catch(failed);
       } else if (this.state.mode === 'single') {
-        const pid = parseInt(this.state.search_param.substr(1), 10);
+        let param = this.state.search_param.substr(1);
+        if (param in window.config.alias) param = window.config.alias[param];
+        const pid = parseInt(param, 10);
         API.get_single(pid, this.props.token)
           .then((json) => {
             this.setState({


### PR DESCRIPTION
可以在设置界面中为树洞号设置“别名”，格式为洞号（PID）+半角空格+别名，将 \#别名 搜索转义为 \#PID 搜索。
比如添加一条“1416897 热榜”，在搜索框中输入 \#热榜 就等于输入 \#1416897。
同一个洞号可以有多个别名。

这样既可以实现需要看热榜（或其他任意洞）的同学能轻松访问（虽然还比不上隔壁那么轻松），也不需要置顶热榜来扰乱不想看热榜的同学的时间线。

另外，将设置中 textarea 的组件重构了一下，并且换用 onBlur 保存了（不能去掉 onChange， 否则 textarea 的 value 是不可变的）。设置界面的样式也微调了一下。