### PR TITLE
Fix reverse with lazyload check

### DIFF
--- a/src/Flows.js
+++ b/src/Flows.js
@@ -460,9 +460,10 @@ class FlowSidebar extends PureComponent {
       : this.state.replies.slice();
     if (this.state.rev) replies_to_show.reverse();
 
+    // may not need key, for performance
     // key for lazyload elem
-    let view_mode_key =
-      (this.state.rev ? 'y-' : 'n-') + (this.state.filter_name || 'null');
+    // let view_mode_key =
+    //   (this.state.rev ? 'y-' : 'n-') + (this.state.filter_name || 'null');
 
     let replies_cnt = { [DZ_NAME]: 1 };
     replies_to_show.forEach((r) => {
@@ -580,9 +581,9 @@ class FlowSidebar extends PureComponent {
               条回复被删除
             </div>
           )}
-        {replies_to_show.map((reply) => (
+        {replies_to_show.map((reply, i) => (
           <LazyLoad
-            key={reply.cid + view_mode_key}
+            key={i}
             offset={1500}
             height="5em"
             overflow={true}

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -18,7 +18,7 @@ import {
   ColoredSpan,
 } from './Common';
 import './Flows.css';
-import LazyLoad from './react-lazyload/src';
+import LazyLoad, { forceCheck } from './react-lazyload/src';
 import { AudioWidget } from './AudioWidget';
 import { TokenCtx, ReplyForm } from './UserAction';
 
@@ -427,9 +427,7 @@ class FlowSidebar extends PureComponent {
   }
 
   toggle_rev() {
-    this.setState((prevState) => ({
-      rev: !prevState.rev,
-    }));
+    this.setState((prevState) => ({ rev: !prevState.rev }), forceCheck);
   }
 
   show_reply_bar(name, event) {


### PR DESCRIPTION
Simple reverse will not trigger lazyload re-check. This can be a bug on very long main thread (1501637). When click reverse, no comment mounts.

Force check fixes this problem.

![437c44ca2ec8e444236e259b1c4d643](https://user-images.githubusercontent.com/36528777/86523906-f6ef9880-bea5-11ea-929f-83b432d05165.jpg)
