### PR TITLE
feat(sidebar): add alias button

### DIFF
--- a/src/Flows.css
+++ b/src/Flows.css
@@ -283,6 +283,11 @@
     opacity: .4;
 }
 
+/* .sidebar-toolbar>.box {
+    display: flex;
+    align-items: stretch;
+} */
+
 .sidebar-toolbar-item {
     padding: 0 0.25em 0 0.25em;
 }
@@ -324,4 +329,33 @@
 
 .sidebar-toolbar-dropdown-item {
     padding: 0.25em 0 0.25em 0;
+}
+
+@media screen and (max-width: 415px) {
+    .sidebar-toolbar-dropdown-title label {
+        display: none;
+    }
+    .sidebar-toolbar-dropdown-content {
+        left: -4em;
+        right: 0.25em;
+    }
+}
+
+@media screen and (max-width: 370px) {
+    .sidebar-toolbar label,
+    .sidebar-toolbar .icon
+    {
+        font-size: 85%;
+    }
+    .sidebar-toolbar-dropdown-content {
+        padding: 0 0.4em 0.25em 0.4em !important;
+    }
+}
+
+@media screen and (max-width: 340px) {
+    .sidebar-toolbar label,
+    .sidebar-toolbar .icon
+    {
+        font-size: 75%;
+    }
 }

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -282,3 +282,46 @@
     padding: 0 .5em;
     opacity: .4;
 }
+
+.sidebar-toolbar-item {
+    padding: 0 0.25em 0 0.25em;
+}
+
+.sidebar-toolbar-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.sidebar-toolbar-dropdown-content {
+    display: none;
+    position: absolute;
+    left: -0.25em;
+    right: -0.25em;
+    text-align: left;
+    /* min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    padding: 12px 16px; */
+    z-index: 1;
+}
+
+.sidebar-toolbar-dropdown:hover .sidebar-toolbar-dropdown-content {
+    display: block;
+    padding: 0.25em 0.5em 0.5em 0.5em;
+}
+
+.sidebar-toolbar-dropdown-content {
+    background-color: var(--box-bgcolor-light);
+    color: black;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,.4);
+}
+
+.root-dark-mode .sidebar-toolbar-dropdown-content {
+    background-color: var(--box-bgcolor-dark);
+    color: var(--foreground-dark);
+    box-shadow: 0 0 2px rgba(255,255,255,.25), 0 0 7px rgba(0,0,0,.15);
+}
+
+.sidebar-toolbar-dropdown-item {
+    padding: 0.25em 0 0.25em 0;
+}

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -425,23 +425,23 @@ class FlowSidebar extends PureComponent {
   set_alias() {
     load_config();
     let alias = prompt(`给 #${this.state.info.pid} 添加别名：`);
-    if (alias !== null) {
-      if (!alias.includes(' ')) {
-        let override = true;
-        if (
-          alias in window.config.alias &&
-          this.state.info.pid !== window.config.alias[alias]
-        ) {
-          override = confirm(
-            `是否将“${alias}”从 #${window.config.alias[alias]} 改为 #${this.state.info.pid}？`,
-          );
-        }
-        if (override) {
-          window.config.alias[alias] = this.state.info.pid;
-          save_config();
-        } else alert('取消设置别名');
-      } else alert('别名不合法，设置别名失败');
-    } else alert('取消设置别名');
+    if (alias === null) return;
+    if (alias.includes(' ')) return alert('别名不合法，设置别名失败');
+
+    let override = true;
+    if (
+      alias in window.config.alias &&
+      this.state.info.pid !== window.config.alias[alias]
+    ) {
+      override = confirm(
+        `是否将“${alias}”从 #${window.config.alias[alias]} ` +
+          `改为 #${this.state.info.pid}？`,
+      );
+    }
+    if (override) {
+      window.config.alias[alias] = this.state.info.pid;
+      save_config();
+    }
   }
 
   set_filter_name(name) {

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -23,7 +23,6 @@ import { AudioWidget } from './AudioWidget';
 import { TokenCtx, ReplyForm } from './UserAction';
 
 import { API, PKUHELPER_ROOT } from './flows_api';
-import { config } from 'pressure';
 
 import { load_config, save_config } from './Config';
 
@@ -521,7 +520,7 @@ class FlowSidebar extends PureComponent {
 
     return (
       <div className="flow-item-row sidebar-flow-item">
-        <div className="box box-tip">
+        <div className="box box-tip sidebar-toolbar">
           {!!this.props.token && (
             <span className="sidebar-toolbar-item">
               <a onClick={this.report.bind(this)}>
@@ -569,7 +568,7 @@ class FlowSidebar extends PureComponent {
             <span className="sidebar-toolbar-dropdown sidebar-toolbar-item">
               <span className="sidebar-toolbar-dropdown-title">
                 <a>
-                  <span className="icon icon-menu" />
+                  <span className="icon">⋯</span>
                   <label>更多▾</label>
                 </a>
               </span>

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -23,6 +23,9 @@ import { AudioWidget } from './AudioWidget';
 import { TokenCtx, ReplyForm } from './UserAction';
 
 import { API, PKUHELPER_ROOT } from './flows_api';
+import { config } from 'pressure';
+
+import { load_config, save_config } from './Config';
 
 const IMAGE_BASE = PKUHELPER_ROOT + 'services/pkuhole/images/';
 const AUDIO_BASE = PKUHELPER_ROOT + 'services/pkuhole/audios/';
@@ -420,6 +423,28 @@ class FlowSidebar extends PureComponent {
     }
   }
 
+  set_alias() {
+    load_config();
+    let alias = prompt(`给 #${this.state.info.pid} 添加别名：`);
+    if (alias !== null) {
+      if (!alias.includes(' ')) {
+        let override = true;
+        if (
+          alias in window.config.alias &&
+          this.state.info.pid !== window.config.alias[alias]
+        ) {
+          override = confirm(
+            `是否将“${alias}”从 #${window.config.alias[alias]} 改为 #${this.state.info.pid}？`,
+          );
+        }
+        if (override) {
+          window.config.alias[alias] = this.state.info.pid;
+          save_config();
+        } else alert('取消设置别名');
+      } else alert('别名不合法，设置别名失败');
+    } else alert('取消设置别名');
+  }
+
   set_filter_name(name) {
     this.setState((prevState) => ({
       filter_name: name === prevState.filter_name ? null : name,
@@ -498,21 +523,21 @@ class FlowSidebar extends PureComponent {
       <div className="flow-item-row sidebar-flow-item">
         <div className="box box-tip">
           {!!this.props.token && (
-            <span>
+            <span className="sidebar-toolbar-item">
               <a onClick={this.report.bind(this)}>
                 <span className="icon icon-flag" />
                 <label>举报</label>
               </a>
-              &nbsp;&nbsp;
             </span>
           )}
-          <a onClick={this.load_replies.bind(this)}>
-            <span className="icon icon-refresh" />
-            <label>刷新</label>
-          </a>
+          <span className="sidebar-toolbar-item">
+            <a onClick={this.load_replies.bind(this)}>
+              <span className="icon icon-refresh" />
+              <label>刷新</label>
+            </a>
+          </span>
           {(this.state.replies.length >= 1 || this.state.rev) && (
-            <span>
-              &nbsp;&nbsp;
+            <span className="sidebar-toolbar-item">
               <a onClick={this.toggle_rev.bind(this)}>
                 <span className="icon icon-order-rev" />
                 <label>{this.state.rev ? '还原' : '逆序'}</label>
@@ -520,8 +545,7 @@ class FlowSidebar extends PureComponent {
             </span>
           )}
           {!!this.props.token && (
-            <span>
-              &nbsp;&nbsp;
+            <span className="sidebar-toolbar-item">
               <a
                 onClick={() => {
                   this.toggle_attention();
@@ -539,6 +563,24 @@ class FlowSidebar extends PureComponent {
                   </span>
                 )}
               </a>
+            </span>
+          )}
+          {!!this.props.token && (
+            <span className="sidebar-toolbar-dropdown sidebar-toolbar-item">
+              <span className="sidebar-toolbar-dropdown-title">
+                <a>
+                  <span className="icon icon-menu" />
+                  <label>更多▾</label>
+                </a>
+              </span>
+              <div className="sidebar-toolbar-dropdown-content">
+                <div className="sidebar-toolbar-dropdown-item">
+                  <a onClick={this.set_alias.bind(this)}>
+                    <span className="icon icon-link" />
+                    <label>别名</label>
+                  </a>
+                </div>
+              </div>
             </span>
           )}
         </div>
@@ -848,7 +890,9 @@ class FlowItemRow extends PureComponent {
                   <span className="box-header-tag">{this.props.info.tag}</span>
                 )}
                 <Time stamp={this.props.info.timestamp} />
-                <span className="box-header-badge"><span className="icon icon-block" /></span>
+                <span className="box-header-badge">
+                  <span className="icon icon-block" />
+                </span>
                 <div style={{ clear: 'both' }} />
               </div>
             </div>

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -434,7 +434,7 @@ class FlowSidebar extends PureComponent {
       this.state.info.pid !== window.config.alias[alias]
     ) {
       override = confirm(
-        `是否将“${alias}”从 #${window.config.alias[alias]} ` +
+        `是否将“#${alias}”从 #${window.config.alias[alias]} ` +
           `改为 #${this.state.info.pid}？`,
       );
     }

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -568,7 +568,7 @@ class FlowSidebar extends PureComponent {
             <span className="sidebar-toolbar-dropdown sidebar-toolbar-item">
               <span className="sidebar-toolbar-dropdown-title">
                 <a>
-                  <span className="icon">⋯</span>
+                  <span className="icon icon-menu" />
                   <label>更多▾</label>
                 </a>
               </span>


### PR DESCRIPTION
feat(sidebar): modify toolbar style
feat(sidebar): add toolbar dropdown

现可在侧边栏中直接为当前树洞添加别名。

原本的工具栏用空格调整按钮间距，现在改为用 CSS 调整。
增加的下拉按钮全部用 CSS 实现，但移动端 :hover 操作略有不便。

![image](https://user-images.githubusercontent.com/21151119/87226150-7c9ea700-c3c4-11ea-8c6a-1162ee07824e.png)