### PR TITLE
feat(flow): sort attention list by latest reply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9267,11 +9267,11 @@
       "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -9280,6 +9280,21 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
       }
     },
     "p-map": {
@@ -9304,9 +9319,9 @@
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "copy-to-clipboard": "^3.3.1",
     "fix-orientation": "^1.1.0",
     "load-script": "^1.0.0",
+    "p-limit": "^3.0.2",
     "pressure": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.0",

--- a/src/Config.js
+++ b/src/Config.js
@@ -18,6 +18,7 @@ const DEFAULT_CONFIG = {
   color_scheme: 'default',
   block_words: [],
   alias: {},
+  attention_sort: false,
 };
 
 export function load_config() {
@@ -390,6 +391,13 @@ export class ConfigUI extends PureComponent {
                 });
               return map;
             }}
+          />
+          <hr />
+          <ConfigSwitch
+            callback={this.save_changes_bound}
+            id="attention_sort"
+            name="关注列表排序"
+            description="启用后，可以将关注列表按最后回复时间排序。不建议在性能较差的设备上启用"
           />
           <hr />
           <ConfigSwitch

--- a/src/Config.js
+++ b/src/Config.js
@@ -419,6 +419,7 @@ export class ConfigUI extends PureComponent {
               return map;
             }}
           />
+          <hr />
           <ConfigSwitch
             callback={this.save_changes_bound}
             id="attention_sort"

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -288,6 +288,10 @@
     font-size: 95%;
 }
 
-.title-button a:not(:hover) {
+.title-button a {
     color: #fff; 
+}
+
+.title-button a:hover {
+    border: none;
 }

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -282,3 +282,12 @@
     padding: 0 .5em;
     opacity: .4;
 }
+
+.title-button {
+    text-align: center;
+    font-size: 95%;
+}
+
+.title-button a:not(:hover) {
+    color: #fff; 
+}

--- a/src/Flows.css
+++ b/src/Flows.css
@@ -289,7 +289,7 @@
 }
 
 .title-button a {
-    color: #fff; 
+    color: lightgoldenrodyellow; 
 }
 
 .title-button a:hover {

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -848,7 +848,9 @@ class FlowItemRow extends PureComponent {
                   <span className="box-header-tag">{this.props.info.tag}</span>
                 )}
                 <Time stamp={this.props.info.timestamp} />
-                <span className="box-header-badge"><span className="icon icon-block" /></span>
+                <span className="box-header-badge">
+                  <span className="icon icon-block" />
+                </span>
                 <div style={{ clear: 'both' }} />
               </div>
             </div>
@@ -1105,7 +1107,6 @@ export class Flow extends PureComponent {
             regex_search = /.+/;
           }
         }
-        console.log(use_search, use_regex);
         API.get_attention(this.props.token)
           .then((json) => {
             this.setState({

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -639,7 +639,9 @@ class FlowItemRow extends PureComponent {
         props.attention_override === null ? false : props.attention_override,
       cached: true, // default no display anything
     };
-    this.color_picker = new ColorPicker();
+    this.color_picker = props.info.reply_color_picker
+      ? props.info.reply_color_picker
+      : new ColorPicker();
   }
 
   componentDidMount() {
@@ -658,6 +660,40 @@ class FlowItemRow extends PureComponent {
       reply_status: 'loading',
       reply_error: null,
     });
+
+    if (this.state.info.use_reply_promise) {
+      this.state.info.reply_promise
+        .then(({ data: json, cached, latest_reply }) => {
+          this.setState(
+            (prev, props) => ({
+              replies: json.data,
+              info: Object.assign({}, prev.info, {
+                reply: update_count ? '' + json.data.length : prev.info.reply,
+                variant: json.data.length ? { latest_reply } : {}, // info._latest_reply in state is always null, Don't use it!
+              }),
+              attention: !!json.attention,
+              reply_status: 'done',
+              reply_error: null,
+              cached,
+            }),
+            callback,
+          );
+        })
+        .catch((e) => {
+          console.error(e);
+          this.setState(
+            {
+              replies: [],
+              reply_status: 'failed',
+              reply_error: '' + e,
+            },
+            callback,
+          );
+        });
+
+      return;
+    }
+
     API.load_replies_with_cache(
       this.state.info.pid,
       this.props.token,
@@ -959,9 +995,12 @@ function FlowChunk(props) {
       {({ value: token }) => (
         <div className="flow-chunk">
           {!!props.title && <TitleLine text={props.title} />}
+          <p className="title-button black-outline">
+            {!!props.title_button && props.title_button}
+          </p>
           {props.list.map((info, ind) => (
             <LazyLoad
-              key={info.pid}
+              key={`${info.pid}-${props.lazyload_key_suffix}`}
               offset={1500}
               height="15em"
               hiddenIfInvisible={true}
@@ -1011,9 +1050,65 @@ export class Flow extends PureComponent {
       },
       loading_status: 'done',
       error_msg: null,
+      reply_promises_done: false,
+      sort_by_latest_reply: false,
+      lazyload_key_suffix: 0,
     };
     this.on_scroll_bound = this.on_scroll.bind(this);
+    this.reply_promises = [];
     window.LATEST_POST_ID = parseInt(localStorage['_LATEST_POST_ID'], 10) || 0;
+  }
+
+  inject_reply_promises(data) {
+    let reply_promise;
+    let color_picker;
+    for (let post of data) {
+      color_picker = new ColorPicker();
+      reply_promise = new Promise((resolve, reject) => {
+        console.log('fetching reply with promise', post.pid);
+        API.load_replies_with_cache(
+          post.pid,
+          this.props.token,
+          color_picker,
+          parseInt(post.reply),
+        )
+          .then(({ data: json, cached }) => {
+            let latest_reply = json.data.length
+              ? Math.max.apply(
+                  null,
+                  json.data.map((r) => parseInt(r.timestamp)),
+                )
+              : post.timestamp;
+            post._latest_reply = latest_reply;
+            resolve({
+              data: json,
+              cached,
+              latest_reply,
+            });
+          })
+          .catch((e) => {
+            console.error(e);
+            reject(e);
+          });
+      });
+      post.use_reply_promise = true;
+      post.reply_color_picker = color_picker;
+      post.reply_promise = reply_promise;
+      this.reply_promises.push(reply_promise);
+      post._latest_reply = null; // This value is not a promise and can only be used in Flow component!
+    }
+
+    Promise.all(this.reply_promises)
+      .then((replies) => {
+        this.setState((prev) => ({
+          reply_promises_done: true,
+        }));
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+
+    return data;
   }
 
   load_page(page) {
@@ -1118,15 +1213,19 @@ export class Flow extends PureComponent {
                       : `Result for "${this.state.search_param}" in `
                     : ''
                 }Attention List`,
-                data: !use_search
-                  ? json.data
-                  : !use_regex
-                  ? json.data.filter((post) => {
-                      return this.state.search_param
-                        .split(' ')
-                        .every((keyword) => post.text.includes(keyword));
-                    }) // Not using regex
-                  : json.data.filter((post) => !!post.text.match(regex_search)), // Using regex
+                data: this.inject_reply_promises(
+                  !use_search
+                    ? json.data // No Search
+                    : !use_regex
+                    ? json.data.filter((post) =>
+                        this.state.search_param
+                          .split(' ')
+                          .every((keyword) => post.text.includes(keyword)),
+                      ) // Search, Not using regex
+                    : json.data.filter(
+                        (post) => !!post.text.match(regex_search),
+                      ), // Search, Using regex
+                ),
               },
               mode: 'attention_finished',
               loading_status: 'done',
@@ -1155,6 +1254,28 @@ export class Flow extends PureComponent {
     }
   }
 
+  sort_by_latest_reply() {
+    this.setState((prev) => ({
+      original_chunk: prev.chunks,
+      chunks: {
+        title: prev.chunks.title,
+        data: prev.chunks.data
+          .slice(0)
+          .sort((a, b) => b._latest_reply - a._latest_reply),
+      },
+      lazyload_key_suffix: prev.lazyload_key_suffix + 1,
+      sort_by_latest_reply: true,
+    }));
+  }
+
+  sort_by_original() {
+    this.setState((prev) => ({
+      chunks: prev.original_chunk,
+      lazyload_key_suffix: prev.lazyload_key_suffix + 1,
+      sort_by_latest_reply: false,
+    }));
+  }
+
   componentDidMount() {
     this.load_page(1);
     window.addEventListener('scroll', this.on_scroll_bound);
@@ -1167,15 +1288,24 @@ export class Flow extends PureComponent {
 
   render() {
     const should_deletion_detect = localStorage['DELETION_DETECT'] === 'on';
+    let title_button_sort =
+      this.state.reply_promises_done &&
+      (this.state.sort_by_latest_reply ? (
+        <a onClick={this.sort_by_original.bind(this)}>按最新回复时间排序</a>
+      ) : (
+        <a onClick={this.sort_by_latest_reply.bind(this)}>按发布时间排序</a>
+      ));
     return (
       <div className="flow-container">
         <FlowChunk
           title={this.state.chunks.title}
+          title_button={title_button_sort}
           list={this.state.chunks.data}
           mode={this.state.mode}
           search_param={this.state.search_param || null}
           show_sidebar={this.props.show_sidebar}
           deletion_detect={should_deletion_detect}
+          lazyload_key_suffix={this.state.lazyload_key_suffix}
         />
         {this.state.loading_status === 'failed' && (
           <div className="aux-margin">

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -1296,9 +1296,9 @@ export class Flow extends PureComponent {
     let title_button_sort =
       this.state.reply_promises_done &&
       (this.state.sort_by_latest_reply ? (
-        <a onClick={this.sort_by_original.bind(this)}>按最新回复时间排序</a>
+        <a onClick={this.sort_by_original.bind(this)}>[ 按最新回复时间排序 ]</a>
       ) : (
-        <a onClick={this.sort_by_latest_reply.bind(this)}>按发布时间排序</a>
+        <a onClick={this.sort_by_latest_reply.bind(this)}>[ 按发布时间排序 ]</a>
       ));
     if (this.state.reply_promises_done) console.log('promise done');
     return (


### PR DESCRIPTION
按 #35 的[设想](https://github.com/AllanChain/PKUHoleCommunity/issues/19#issuecomment-657939804)，通过把回复加载从 LazyLoad 换用 Promise，回复数据提前到更外层的 Flow 组件获取，按回复时间排序得以实现。
但同时引入并发加载过多回复的风险，目前尝试设置为每次最多并发加载 **25** 条回复，可以通过 [MAX_PARALLEL](https://github.com/AllanChain/PKUHoleCommunity/blob/35af0bf6010ffcd2be24f8f590f590351430116e/src/Flows.js#L1066) 调整。

需要在设置里手动开启 attention_sort 选项。
