### PR TITLE
修复不咕计划链接

### DIFF
--- a/src/Title.js
+++ b/src/Title.js
@@ -14,6 +14,7 @@ const APP_SWITCHER_ROUTER = {
   客户端: 'https://pkuhelper.pku.edu.cn/',
   成绩: 'https://pkuhelper.pku.edu.cn/my_score',
   不咕: 'https://pkuhelper.pku.edu.cn/ddl',
+  不咕计划: 'https://pkuhelper.pku.edu.cn/ddl',
   课程测评: 'https://courses.pinzhixiaoyuan.com/',
   测评: 'https://courses.pinzhixiaoyuan.com/',
 };


### PR DESCRIPTION
在 `APP_SWITCHER` 中添加了“不咕计划”的链接（原名“不咕”，为了对齐被改为四字）