### PR TITLE
feat: 仅复制当前显示的回复

### DIFF
--- a/src/Flows.css
+++ b/src/Flows.css
@@ -206,7 +206,7 @@
 }
 
 .box-id a:hover::before {
-    content: "复制全文";
+    content: var(--box-id-copy-content, "复制");
     position: relative;
     width: 5em;
     height: 1.3em;

--- a/src/Flows.js
+++ b/src/Flows.js
@@ -175,8 +175,12 @@ class FlowItem extends PureComponent {
         }\n` +
         `（${format_time(new Date(this.props.info.timestamp * 1000))} ${
           this.props.info.likenum
-        }关注 ${this.props.info.reply}回复）\n` +
-        this.props.replies
+        }关注 ${this.props.info.reply}回复${
+          this.props.replies_filter_name
+            ? ` 只看[${this.props.replies_filter_name}]`
+            : ''
+        }${this.props.replies_is_rev ? ' 逆序' : ''}）\n` +
+        this.props.replies_to_show
           .map((r) => (r.tag ? '【' + r.tag + '】' : '') + r.text)
           .join('\n'),
     );
@@ -239,7 +243,14 @@ class FlowItem extends PureComponent {
                 <span className="icon icon-reply" />
               </span>
             )}
-            <code className="box-id">
+            <code
+              className="box-id"
+              style={{
+                '--box-id-copy-content': props.replies_filter_name
+                  ? `"仅复制${props.replies_filter_name}"`
+                  : '"复制全文"',
+              }}
+            >
               <a
                 href={'##' + props.info.pid}
                 onClick={this.copy_link.bind(this)}
@@ -512,6 +523,9 @@ class FlowSidebar extends PureComponent {
             color_picker={this.color_picker}
             show_pid={show_pid}
             replies={this.state.replies}
+            replies_to_show={replies_to_show}
+            replies_filter_name={this.state.filter_name}
+            replies_is_rev={this.state.rev}
             set_variant={(variant) => {
               this.set_variant(null, variant);
             }}
@@ -860,6 +874,9 @@ class FlowItemRow extends PureComponent {
           color_picker={this.color_picker}
           show_pid={show_pid}
           replies={this.state.replies}
+          replies_to_show={this.state.replies}
+          replies_filter_name={null}
+          replies_is_rev={false}
           cached={this.state.cached}
         />
         <div className="flow-reply-row">


### PR DESCRIPTION
![Snipaste_2022-02-09_23-18-42](https://user-images.githubusercontent.com/21151119/153231248-475aea06-10f0-4cff-8092-afc8e2ac10b6.png)

在侧边栏中复制时若应用了只看 XX 或是逆序，则只复制当前显示的回复。
在主 Feed 中复制时不受影响。