### PR TITLE
可选的自动人机验证

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG = {
   block_words: [],
   alias: {},
   attention_sort: false,
+  auto_captcha: false,
 };
 
 export function load_config() {
@@ -423,6 +424,12 @@ export class ConfigUI extends PureComponent {
             id="attention_sort"
             name="关注列表排序"
             description="启用后，可以将关注列表按最后回复时间排序。不建议在性能较差的设备上启用"
+          />
+          <ConfigSwitch
+            callback={this.save_changes_bound}
+            id="auto_captcha"
+            name="自动人机验证"
+            description="启用后，将自动完成人机验证。不稳定。"
           />
         </div>
         <div className="box">

--- a/src/flows_api.js
+++ b/src/flows_api.js
@@ -129,7 +129,16 @@ export const API = {
     const response = await fetch(
       API_BASE + '/api.php?action=getlist' + '&p=' + page + token_param(token),
     );
-    return handle_response(response);
+    const json = await handle_response(response);
+    if (json.data.every((info) => info.text.startsWith('为保障树洞信息安全'))) {
+      iframe_captcha_manager.load_iframe();
+      return new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
+        API.get_list(page, token),
+      );
+    } else {
+      iframe_captcha_manager.remove_iframe();
+      return json;
+    }
   },
 
   get_search: async (page, keyword, token) => {


### PR DESCRIPTION
原理是使用 iframe 打开官方树洞网页，让它自动进行人机验证。

尚未解决的问题：

- [ ] 打开 iframe 并完成验证需要较长时间，此时 UI 没有反馈
- [ ] 只对获取评论和时间线列表有检测（不过应该也够了）
- [x] 未处理人机验证失败和超时的情况
- [ ] 等待时间目前固定为一秒